### PR TITLE
chore: using default imports for ansi-colors because of the vite bug

### DIFF
--- a/stores/cache-store.ts
+++ b/stores/cache-store.ts
@@ -1,8 +1,13 @@
 import type { IDBPDatabase } from 'idb';
 import { openDB } from 'idb';
-import { green, red, yellow } from 'ansi-colors';
+
+// eslint-disable-next-line import/default
+import colors from 'ansi-colors';
 import type { CacheSchema, DriveFile, GetFilesOptions, RawMediaObject } from '~/models/types';
 import { isDriveFile } from '~/models/types';
+
+// eslint-disable-next-line import/no-named-as-default-member
+const { green, red, yellow } = colors;
 
 const formatIds = (
   requested: string[] | number[],

--- a/stores/drive-file-store.ts
+++ b/stores/drive-file-store.ts
@@ -1,4 +1,5 @@
-import { bgGreen, bgWhite, bgYellow } from 'ansi-colors';
+// eslint-disable-next-line import/default
+import colors from 'ansi-colors';
 import { DataRetrievalStrategies, updateFieldMask } from '~/models/types';
 import type {
   AppProperties,
@@ -24,6 +25,9 @@ import {
 import { serializeAppProperties } from '~/utils/appPropertiesSerializer';
 import { convertToDriveFile } from '~/models/DriveFile';
 import { extractErrorMessage } from '~/utils/extractErrorMessage';
+
+// eslint-disable-next-line import/no-named-as-default-member
+const { bgGreen, bgWhite, bgYellow } = colors;
 
 type FileRequest = gapi.client.Request<gapi.client.drive.File>;
 type FileResponse = gapi.client.Response<gapi.client.drive.File>;


### PR DESCRIPTION
fixes import problems with ansi-colors, see https://vite-plugin-ssr.com/broken-npm-package#named-export-not-found